### PR TITLE
kubernetes社区prow机器人介绍

### DIFF
--- a/content/post/cncf/kubernetes/prow.md
+++ b/content/post/cncf/kubernetes/prow.md
@@ -1,0 +1,20 @@
+---
+layout:     post 
+slug:      "prow"
+title:      "prow"
+subtitle:   ""
+description: ""
+date:       2023-11-07
+author:     "梁远鹏"
+image: "/img/banner-pexels.jpg"
+published: true
+wipnote: true
+tags:
+    - k8s
+    - kubernetes
+    - cncf
+    - golang
+categories: [ kubernetes ]
+---
+
+# 


### PR DESCRIPTION

目前只是一个占位符， prow部署发生了一些变更，以前似乎没有要求作为 github app，现在需要了。